### PR TITLE
fixed bugs for report pdf/csv

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from models import db, Events, User
 from load_data import load_events
 from views import main_blueprint
 from auth import auth_blueprint, init_oauth
+from report_gen import reports_bp
 import os
 
 login_manager = LoginManager()
@@ -32,6 +33,8 @@ def create_app():
     # Register blueprints
     app.register_blueprint(main_blueprint)
     app.register_blueprint(auth_blueprint)
+    app.register_blueprint(reports_bp, url_prefix="/api/reports")
+    
 
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
## PR: Fix report generation template variables

### Why this change
The `api_generate_report` function was failing when rendering `standalone_report.html` because the template expected variables (`js_pie_labels`, `js_pie_values`) that were not defined. This caused a `TypeError: Object of type Undefined is not JSON serializable` when Flask tried to convert these values to JSON for the chart.  

This change calculates the labels and values for the pie chart based on the events' types and passes them to the template. It also ensures the monthly events and attendance data are properly passed for charting.

### Acceptance Criteria
- [x] Report generation no longer throws a `TypeError` for undefined variables.  
- [x] `standalone_report.html` receives:
  - `js_pie_labels` → list of event type names  
  - `js_pie_values` → corresponding counts  
  - `months` → list of event counts by month  
  - `attendance` → list of attendance totals by month  
- [x] Generated reports display pie charts and monthly charts correctly.  
- [x] The `/api/reports/generate` endpoint returns a valid URL to the generated HTML file.

### Notes
- No database or model changes required.  
- Existing functionality for filtering by year and fallback to all years remains unchanged.  
- Ensures that all chart-related variables used in `standalone_report.html` are always defined.  
- Minor improvement: uses `Counter` to calculate event type counts for pie chart.
